### PR TITLE
fix: using 'false' from configuration and example for lustre

### DIFF
--- a/infrastructure/stacks/storage_stack.py
+++ b/infrastructure/stacks/storage_stack.py
@@ -65,7 +65,7 @@ class StorageStack(Stack):
                 The created Lustre file system and SSM document, or (None, None) if not enabled.
         """
         lustre_enable = self.node.try_get_context("batch-ffmpeg:lustre-fs:enable")
-        if not lustre_enable:
+        if str(lustre_enable).lower() == "false":
             return None, None
         logging.info("Creating FSx for Lustre file system")
         lustre_subnet = self.vpc.select_subnets(


### PR DESCRIPTION

*Description of changes:*
The storage module ‘lustre-fs’ has a configuration option to enable or disable the CDK stack. In the configuration, the boolean ‘false’ is used, but this has no effect in the current code that checks whether this feature is enabled because Python expects ‘False’ instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
